### PR TITLE
Check response type and body before calling childs

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function livereload(opts) {
     }
 
     // stream
-    if (typeof this.body.pipe === 'function') {
+    if (this.body && typeof this.body.pipe === 'function') {
       var injecter = new StreamInjecter({
         matchRegExp : /(<\/body>)/,
         inject : snippet,


### PR DESCRIPTION
I have run into this, and added a checks before calling or checking childs.

> TypeError: Cannot call method 'indexOf' of undefined
> at Object.livereload (/Users/dejanr/Projects/.../node_modules/koa-livereload/index.js:13:28)
> 
> TypeError: Cannot read property 'pipe' of undefined
>  at Object.livereload (/Users/dejanr/Projects/.../node_modules/koa-livereload/index.js:27:25)
