### PR TITLE
Support Koa v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 test:
-	        @NODE_ENV=test ./node_modules/.bin/mocha \
-						                --require should \
-														                --harmony-generators \
-																						                --reporter spec \
-																														                --bail
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+		--require should \
+		--reporter spec \
+		--bail
 
 clean:
-	        @rm -rf node_modules
+	@rm -rf node_modules
 
 .PHONY: test clean

--- a/index.js
+++ b/index.js
@@ -8,13 +8,11 @@ function livereload(opts) {
   var src = opts.src || "' + (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + port + "/livereload.js?snipver=1";
   var snippet = "\n<script type=\"text/javascript\">document.write('<script src=\"" + src + "\" type=\"text/javascript\"><\\/script>')</script>\n";
   return (ctx, next) => next().then(() => {
-    if (ctx.response.type && ctx.response.type.indexOf('html') < 0) return;
+    if (ctx.response.type && !ctx.response.type.includes('html')) return;
 
     if (opts.excludes) {
       var path = ctx.path;
-      if (opts.excludes.some(function (exlude) {
-        return path.substr(0, exlude.length) === exlude;
-      })) return;
+      if (opts.excludes.some(exclude => path.startsWith(exclude))) return;
     }
 
     // Buffer

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "koa": "~0.1.2",
     "koa-static": "~1.4.0",
     "should": "~2.1.1",
-    "mocha": "~1.16.2",
+    "mocha": "^2.5.3",
     "supertest": "~0.8.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "dependencies": {
     "stream-injecter": "0.0.1",
-    "koa": "~0.1.2"
+    "koa": "^2.0.0"
   },
   "devDependencies": {
-    "koa": "~0.1.2",
-    "koa-static": "~1.4.0",
+    "koa": "^2.0.0",
+    "koa-static": "^3.0.0",
     "should": "~2.1.1",
     "mocha": "^2.5.3",
     "supertest": "~0.8.2"

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var request = require('supertest');
 var assert = require('assert');
 var http = require('http');
-var koa = require('koa');
+var Koa = require('koa');
 var serve = require('koa-static');
 var Stream = require('stream');
 var fs = require('fs');
@@ -16,21 +16,21 @@ describe("Livereload", function() {
   var expectHtml = '<html><body><h1>TEXT HTML<\/h1>'+ snippet +'<\/body><\/html>';
   fs.writeFileSync(__dirname + "/expect.html", html);
 
-  function* streamHtml(next) {
-    this.response.type = "text/html";
-    this.body = fs.createReadStream(__dirname + "/expect.html");
+  function streamHtml(ctx, next) {
+    ctx.response.type = "text/html";
+    ctx.body = fs.createReadStream(__dirname + "/expect.html");
   }
 
-  function* textHtml(next) {
-    this.body = html;
+  function textHtml(ctx, next) {
+    ctx.body = html;
   }
 
-  function* bufferHtml(next) {
-    this.body = html;
+  function bufferHtml(ctx, next) {
+    ctx.body = html;
   }
 
   it('should contain livereload text', function (done) {
-    var app = koa();
+    var app = new Koa();
     app.use(livereload());
     app.use(textHtml);
     request(app.listen())
@@ -43,9 +43,9 @@ describe("Livereload", function() {
       done();
     });
   });
-  
+
   it('should not contain livereload text on excluded path', function (done) {
-    var app = koa();
+    var app = new Koa();
     app.use(livereload({excludes: ['/partials']}));
     app.use(textHtml);
     request(app.listen())
@@ -60,7 +60,7 @@ describe("Livereload", function() {
   });
 
   it('should contain livereload buffer', function (done) {
-    var app = koa();
+    var app = new Koa();
     app.use(livereload());
     app.use(bufferHtml);
     request(app.listen())
@@ -75,7 +75,7 @@ describe("Livereload", function() {
   });
 
   it('should contain livereload static middleware', function (done) {
-    var app = koa();
+    var app = new Koa();
     app.use(livereload());
     app.use(serve(__dirname));
     request(app.listen())
@@ -90,7 +90,7 @@ describe("Livereload", function() {
   });
 
   it('should contain livereload stream', function (done) {
-    var app = koa();
+    var app = new Koa();
     app.use(livereload());
     app.use(streamHtml);
     request(app.listen())
@@ -103,8 +103,9 @@ describe("Livereload", function() {
       done();
     });
   });
+
   it('should contain livereload stream with port option', function (done) {
-    var app = koa();
+    var app = new Koa();
     var port = 32322;
     var src = "' + (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + port + "/livereload.js?snipver=1";
     var snippet = "\n<script type=\"text/javascript\">document.write('<script src=\"" + src + "\" type=\"text/javascript\"><\\/script>')</script>\n";
@@ -121,8 +122,9 @@ describe("Livereload", function() {
       done();
     });
   });
+
   it('should contain livereload stream with src option', function (done) {
-    var app = koa();
+    var app = new Koa();
     var src = "abc.js";
     var snippet = "\n<script type=\"text/javascript\">document.write('<script src=\"" + src + "\" type=\"text/javascript\"><\\/script>')</script>\n";
     var expectHtml = '<html><body><h1>TEXT HTML<\/h1>'+ snippet +'<\/body><\/html>';


### PR DESCRIPTION
It makes koa-livereload work with Koa v2. This PR is the implementation for #6.

As Koa v2 is not being considered as stable, it may be better to merge this into `next` and release this as `koa-livereload@next`.

If there is any comment, please feel free to let me know.